### PR TITLE
Add validation for pressure input

### DIFF
--- a/frontend/src/components/CalcSpectrum.tsx
+++ b/frontend/src/components/CalcSpectrum.tsx
@@ -5,9 +5,8 @@ import {
   Button,
   FormControl,
   CircularProgress,
-  Input,
   InputAdornment,
-  FormHelperText,
+  TextField,
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 import * as queryString from "query-string";
@@ -78,19 +77,20 @@ const CalcSpectrum: React.FC = () => {
           </Grid>
           <Grid item xs={12}>
             <FormControl>
-              <Input
+              <TextField
                 value={params.pressure}
+                type="number"
                 onChange={(event) =>
                   setParams({ ...params, pressure: event.target.value })
                 }
-                endAdornment={
-                  <InputAdornment position="end">bar</InputAdornment>
-                }
-                aria-describedby="pressure-helper-text"
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">bar</InputAdornment>
+                  ),
+                }}
+                inputProps={{ step: 0.001 }}
+                label="Pressure"
               />
-              <FormHelperText id="pressure-helper-text">
-                Pressure
-              </FormHelperText>
             </FormControl>
           </Grid>
 


### PR DESCRIPTION
<img width="1552" alt="Screen Shot 2020-11-28 at 9 46 59 AM" src="https://user-images.githubusercontent.com/13723264/100519606-acc1c900-315e-11eb-8c6b-d05e068861dd.png">

Could use some improvement as I can still break it (eg. just entering "e" or having no value present), but it's better than before.

Closes #42 