### PR TITLE
Add ability to simulate an experimental slit

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -21,6 +21,7 @@ def call_calc_spectrum():
     min_wavelength_range = int(request.args["minWavelengthRange"])
     max_wavelength_range = int(request.args["maxWavelengthRange"])
     pressure = float(request.args["pressure"])
+    simulate_slit = request.args["simulateSlit"] == "true"
     try:
         spectrum = radis.calc_spectrum(
             min_wavelength_range,
@@ -35,6 +36,9 @@ def call_calc_spectrum():
     except radis.misc.warning.EmptyDatabaseError:
         return {"error": "No spectrum at specified wavelength range"}
     else:
+        if simulate_slit:
+            spectrum.apply_slit(0.5, "nm")
+
         return plot_spectrum(spectrum)
 
 

--- a/frontend/src/components/CalcSpectrum.tsx
+++ b/frontend/src/components/CalcSpectrum.tsx
@@ -14,6 +14,7 @@ import WavenumberRangeSlider from "./WavenumberRangeSlider";
 import { CalcSpectrumParams, PALETTE } from "../constants";
 import MoleculeSelector from "./MoleculeSelector";
 import { addSubscriptsToMolecule } from "../utils";
+import SimulateSlit from "./SimulateSlit";
 
 interface Response<T> {
   data?: T;
@@ -35,6 +36,7 @@ const CalcSpectrum: React.FC = () => {
     minWavenumberRange: 1900,
     maxWavenumberRange: 2300,
     pressure: 1.01325,
+    simulateSlit: false,
   });
   const [loading, setLoading] = useState(false);
 
@@ -92,6 +94,10 @@ const CalcSpectrum: React.FC = () => {
                 label="Pressure"
               />
             </FormControl>
+          </Grid>
+
+          <Grid item xs={12}>
+            <SimulateSlit params={params} setParams={setParams} />
           </Grid>
 
           <Grid item xs={12}>

--- a/frontend/src/components/SimulateSlit.tsx
+++ b/frontend/src/components/SimulateSlit.tsx
@@ -1,0 +1,26 @@
+import { FormControlLabel, Switch } from "@material-ui/core";
+import React from "react";
+import { CalcSpectrumParams } from "../constants";
+
+interface SimulateSlitProps {
+  params: CalcSpectrumParams;
+  setParams: (params: CalcSpectrumParams) => void;
+}
+
+const SimulateSlit: React.FC<SimulateSlitProps> = ({ params, setParams }) => {
+  return (
+    <FormControlLabel
+      control={
+        <Switch
+          checked={params.simulateSlit}
+          onChange={() =>
+            setParams({ ...params, simulateSlit: !params.simulateSlit })
+          }
+        />
+      }
+      label="Simulate an experimental slit"
+    />
+  );
+};
+
+export default SimulateSlit;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,7 +1,8 @@
-export interface CalcSpectrumParams extends Record<string, string | number> {
+export interface CalcSpectrumParams extends Record<string, string | number | boolean> {
   molecule: string;
   minWavenumberRange: number;
   maxWavenumberRange: number;
+  simulateSlit: boolean;
 }
 
 export const PALETTE = {


### PR DESCRIPTION
<img width="1552" alt="Screen Shot 2020-11-28 at 10 24 52 AM" src="https://user-images.githubusercontent.com/13723264/100520561-f8c33c80-3163-11eb-8895-6ed3617a5372.png">

Future TODO: Add ability to parameterize information about the slit.

Closes #45 