### PR TITLE
Center the loading spinner

### DIFF
--- a/frontend/src/components/CalcSpectrum.tsx
+++ b/frontend/src/components/CalcSpectrum.tsx
@@ -285,7 +285,15 @@ const CalcSpectrum: React.FC = () => {
 
         <Grid item xs={8}>
           {loading ? (
-            <CircularProgress />
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                marginTop: 200,
+              }}
+            >
+              <CircularProgress />
+            </div>
           ) : (
             calcSpectrumResponse?.data && (
               <CalcSpectrumPlot


### PR DESCRIPTION
<img width="776" alt="Screen Shot 2020-12-19 at 4 10 54 PM" src="https://user-images.githubusercontent.com/13723264/102700629-c9f52f00-4214-11eb-9ce9-a4f433810dee.png">

Unfortunately couldn't get it to work with material-ui, so I resorted to just plain styling for now...

Closes #56
