### PR TITLE
Add vertical zoom to plot

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -21,7 +21,8 @@
         "**/*.tsx"
       ],
       "rules": {
-        "react/prop-types": "off"
+        "react/prop-types": "off",
+        "@typescript-eslint/ban-ts-comment": "off"
       }
     }
   ]

--- a/src/components/CalcSpectrumPlot.tsx
+++ b/src/components/CalcSpectrumPlot.tsx
@@ -32,16 +32,22 @@ const CalcSpectrumPlot: React.FC<CalcSpectrumPlotProps> = ({
       title: `Spectrum for ${addSubscriptsToMolecule(molecule)}`,
       font: { family: "Roboto", color: "#000" },
       xaxis: {
-        autorange: true,
         range: [minWavenumberRange, maxWavenumberRange],
         title: { text: "Wavenumber (cm⁻¹)" },
-        rangeslider: { range: [minWavenumberRange, maxWavenumberRange] },
+        rangeslider: {
+          // TODO: Update typing in DefinitelyTyped
+          // @ts-ignore
+          autorange: true,
+          // @ts-ignore
+          yaxis: { rangemode: "auto" },
+        },
         type: "linear",
       },
       yaxis: {
         autorange: true,
         title: { text: "Radiance (mW/cm²/sr/nm)" },
         type: "linear",
+        fixedrange: false,
       },
     }}
   />


### PR DESCRIPTION
https://user-images.githubusercontent.com/13723264/103466157-ffffdc00-4d07-11eb-85c2-4050060c5950.mov

I had to add some `@ts-ignore` comments as as the React Plotly types from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) are not up-to-date with Plotly JS. Will try to fix this upstream sometime.

Closes #152