### PR TITLE
Non-eq calculation is available for CO only

### DIFF
--- a/src/components/CalcSpectrum.tsx
+++ b/src/components/CalcSpectrum.tsx
@@ -194,7 +194,7 @@ export const CalcSpectrum: React.FC = () => {
 
   const UseNonEquilibriumCalculations = () => (
     <FormControlLabel
-      label="Use non-equilibrium calculations"
+      label="Use non-equilibrium calculations (CO only)"
       control={
         <Switch
           checked={isNonEquilibrium}


### PR DESCRIPTION
Hello,

A really minor pull request. 

I notice it is possible to launch non-equilibrium calculation for any HITRAN molecule. I'm scared a random user wanting to do this for any other molecule than CO will be frustrated (and may argue that "it doesn't work"). Is it a good idea to append "(CO only)" to "Use non-equilibrium calculation" ?

Nicolas

(Note: first time I try a pull-request online)